### PR TITLE
Fix autoexpanding in firefox

### DIFF
--- a/src/AutoExpand.elm
+++ b/src/AutoExpand.elm
@@ -229,6 +229,7 @@ textareaStyles config rowCount =
                else
                 "scroll-y"
              )
+           , ( "overflow-x", "hidden" )
            ]
         |> style
 


### PR DESCRIPTION
Firefox has a [18-year old bug](https://bugzilla.mozilla.org/show_bug.cgi?id=33654) (wow, I didn't knew the internet existed this long) where the textarea has an extra spacing at the end even with rows=1

This causes autoexpand to not work well in firefox:

<img src="https://user-images.githubusercontent.com/792201/35183316-21e8f6a6-fdcb-11e7-9472-984652798ca7.gif" width="400" />

This commit fixes the issue based on this solution on stack overflow:
https://stackoverflow.com/a/22700700/996404